### PR TITLE
add type hint

### DIFF
--- a/graphannis/cs.py
+++ b/graphannis/cs.py
@@ -270,7 +270,7 @@ class CorpusStorageManager:
 
         return G
 
-    def subcorpus_graph(self, corpus_name: str, document_ids) -> nx.MultiDiGraph:
+    def subcorpus_graph(self, corpus_name: str, document_ids: list) -> nx.MultiDiGraph:
         """ Return the copy of a subgraph which includes all nodes that belong to any of the given list of sub-corpus/document identifiers.
         :param corpus_name:  The name of the corpus for which the subgraph should be generated from.
         :param document_ids: A list of sub-corpus/document identifiers describing the subgraph.


### PR DESCRIPTION
Add a type hint to prevent people from sending a single document ID in string format as a parameter for the subcorpus_graph function (instead of wrapping it as a single element in a list)